### PR TITLE
Ban Mantine and Luck Items from Godly Gift

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -917,9 +917,9 @@ export const Formats: FormatList = [
 		mod: 'gen8',
 		ruleset: ['Standard', 'Dynamax Clause', 'Sleep Moves Clause'],
 		banlist: [
-			'Blissey', 'Calyrex-Shadow', 'Chansey', 'Dragapult', 'Hawlucha', 'Marowak-Alola', 'Melmetal', 'Pikachu', 'Toxapex',
+			'Blissey', 'Calyrex-Shadow', 'Chansey', 'Dragapult', 'Hawlucha', 'Mantine', 'Marowak-Alola', 'Melmetal', 'Pikachu', 'Toxapex',
 			'Xerneas', 'Zacian', 'Zacian-Crowned', 'Uber > 1', 'AG ++ Uber > 1', 'Arena Trap', 'Huge Power', 'Moody', 'Pure Power',
-			'Shadow Tag', 'Baton Pass',
+			'Shadow Tag', 'Baton Pass', 'King\'s Rock', 'Quick Claw', 'Bright Powder', 'Lax Incense', 'Focus Band',
 		],
 		onValidateTeam(team) {
 			const gods = new Set<string>();


### PR DESCRIPTION
Godly Gift has recently banned Mantine, King's Rock, Quick Claw, Bright Powder, Lax Incense, and Focus Band. Proof of the bans can be found here: https://www.smogon.com/forums/threads/godly-gift.3660461/post-9106404